### PR TITLE
ci: test and build for arm64

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,26 +11,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  make-sdist:
-    name: Make SDist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-      - name: Build SDist
-        run: pipx run build --sdist
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cibw-sdist
-          path: dist/*.tar.gz
+  # Disabled until CMakeLists.txt is updated to download everything it needs
+  # make-sdist:
+  #   name: Make SDist
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: "recursive"
+  #     - name: Build SDist
+  #       run: pipx run build --sdist
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: cibw-sdist
+  #         path: dist/*.tar.gz
 
   build-wheels:
     name: Build wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -55,7 +56,7 @@ jobs:
   deploy-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [build-wheels, make-sdist]
+    needs: [build-wheels]
     environment:
       name: pypi
       url: https://pypi.org/p/triangulumancer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14]
         python-version: ["3.9", "3.13"]
     steps:
       - name: Check out repo


### PR DESCRIPTION
Build wheels for linux arm64. Also, disable sdist until CMakeLists.txt can download everything it needs, as otherwise it cannot be built from the contents of the sdist.