### PR TITLE
chore: pin topcom ref

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(FetchContent)
 FetchContent_Declare(
   topcom
   GIT_REPOSITORY https://github.com/ariostas/TOPCOM.git
-  GIT_TAG main)
+  GIT_TAG a4333293e9c3cbcf5b8420b89ee30f51078d47fc)
 FetchContent_MakeAvailable(topcom)
 target_compile_definitions(topcom PUBLIC USE_PHIT_PREPROCESSING=false)
 


### PR DESCRIPTION
This PR pins the topcom ref to a specific commit hash to make sure that later on one can rebuild an older version of triangulumancer (and also for potential security issues). 